### PR TITLE
Fixed bug with SubzoneRecordException, Changed field for DNS name fro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ A [NetBox](https://github.com/digitalocean/netbox) source for [octoDNS](https://
 Based on IP address information managed by NetBox,
 automatically creating A/AAAA records and their corresponding PTR records.
 
-At this time, NetBox does not have a field 'hostname' in IPAddress,
-so we use the 'description' field as a comma-separated list of hostnames (FQDNs).
+NetBox does have a field 'DNS Name' in IPAddress, we use this field as a comma-separated list of hostnames (FQDNs).
 
 ### Example config
 
@@ -14,6 +13,8 @@ The following config will combine the records in `./config/example.com.yaml`
 and the dynamically looked up addresses at NetBox.
 
 You must configure `url` and `token` to work with the [NetBox API](https://netbox.readthedocs.io/en/latest/api/overview/).
+
+Furthermore you can define `tag` as an option. This enables you to define different DNS views by tagging dedicated IP addresses alike. If you like to have the same IP address with different FQDNs in dedicated views, you can add it twice (or even more often) to NetBox.
 
 ```yaml
 providers:
@@ -26,6 +27,7 @@ providers:
     class: octodns_netbox.NetboxSource
     url: https://ipam.example.com/api
     token: env/NETBOX_TOKEN
+    tag: 'dns_intern'
 
   route53:
     class: octodns.provider.route53.Route53Provider


### PR DESCRIPTION
…m 'description' to 'dns_name', Support for Multi-PTR, Tagging for different DNS Views added.

The tagging of IP addresses is eventually a feature more users like to use. It allows to tag IP addresses within NetBox, e.g. with the tags 'dns_intern' and/or 'dns_extern'. If this tag is provided within OctoDNS on provider definition the query for IP addresses and their FQDNs to NetBox is limited to this tag. If a user needs to distinguish between the two DNS Views, the IP address can be registered within NetBox twice, with different FQDNs and the corresponding tag set. Also it allows to register IP addresses within NetBox, while their FQDN will not be used within DNS (empty tag for this IP address). 

Multi-PTRecords are not used often, but allow to resolve an IP address to more than one FQDN. 

I hope that helps. If the list of resolved bugs and added features is to long, I can separate them. Thanks for your work!