### PR TITLE
Optional support for multi-value PTRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ Starting with [Netbox v2.6.0](https://github.com/netbox-community/netbox/issues/
 
 ### PTR records
 
-PTR records supported as well. Multiple PTR records on a single IP is not recommended, but is already properly supported by many providers. OctoDNS [supports it](https://github.com/octodns/octodns/pull/754) with backward compatibility, so that if your DNS provider does not support it, it will [properly handle it so that only single-value is stored](https://github.com/octodns/octodns/blob/6890e3307c7246720820e4dc8f18edc2c8bcf164/octodns/provider/base.py#L91-L102).
+PTR records supported as well. OctoDNS [supports Multiple PTR records on a single IP](https://github.com/octodns/octodns/pull/754), but it is not ot used much in productions. By default, `multivalue_ptr: false` is set and the first FQDN in the field will be used to generate the PTR record.
 
-#### 🔍 Example
+#### 🔍 Example (`multivalue_ptr: false` - default)
+- IP Address: `192.0.2.1/24`
+  - Description: `en0.host1.example.com,host1.example.com`
+- DNS Zone: `2.0.192.in-addr.arpa.`
+  - `1. PTR en0.host1.example.com`
+
+#### 🔍 Example (`multivalue_ptr: true`)
 - IP Address: `192.0.2.1/24`
   - Description: `en0.host1.example.com,host1.example.com`
 - DNS Zone: `2.0.192.in-addr.arpa.`
@@ -89,6 +95,10 @@ providers:
     # If there are multiple VRFs with the same name, it would be better to use `populate_vrf_id`.
     # If `Global`, explicitly points for global VRF.
     populate_vrf_name: mgmt
+    # Multi-value PTR records support (Optional, default: `false`)
+    # If `true`, multiple-valued PTR records will be generated.
+    # If `false`, the first FQDN value in the field will be used.
+    multivalue_ptr: true
 
   route53:
     class: octodns_route53.Route53Provider

--- a/tests/test_octodns_netbox.py
+++ b/tests/test_octodns_netbox.py
@@ -501,7 +501,46 @@ class TestNetboxSourcePopulateIPv4PTROctecBoundary:
     def test_populate_PTR_v4_octet_boundary(self):
         zone = Zone("2.0.192.in-addr.arpa.", [])
         source = NetboxSource(
-            "test", url="http://netbox.example.com/", token="testtoken"
+            "test",
+            url="http://netbox.example.com/",
+            token="testtoken",
+        )
+        source.populate(zone)
+
+        assert len(zone.records) == 2
+
+        expected = Zone("2.0.192.in-addr.arpa.", [])
+        for name, data in (
+            (
+                "1",
+                {
+                    "type": "PTR",
+                    "ttl": 60,
+                    "values": ["description-192-0-2-1.example.com."],
+                },
+            ),
+            (
+                "2",
+                {
+                    "type": "PTR",
+                    "ttl": 60,
+                    "values": ["description-192-0-2-2.example.com."],
+                },
+            ),
+        ):
+            record = Record.new(expected, name, data)
+            expected.add_record(record)
+
+        changes = expected.changes(zone, SimpleProvider())
+        assert changes == []
+
+    def test_populate_PTR_v4_octet_boundary_multivalue_ptr_enabled(self):
+        zone = Zone("2.0.192.in-addr.arpa.", [])
+        source = NetboxSource(
+            "test",
+            url="http://netbox.example.com/",
+            token="testtoken",
+            multivalue_ptr=True,
         )
         source.populate(zone)
 


### PR DESCRIPTION
Multi-value PTR records is indeed [supported by octoDNS](https://github.com/octodns/octodns/pull/754?w=1).
The problem is if unsupported providers (e.g., PowerDNS, Google Cloud DNS) are used. In a backward compatible way, octoDNS will leave only one value.

https://github.com/octodns/octodns/blob/6890e3307c7246720820e4dc8f18edc2c8bcf164/octodns/provider/base.py#L91-L102

However, we cannot choose which to keep. The current implementation seems to keep the first value sorted by name, but this may not be what the user actually wants. 

For instance, I might type `v1001.rtr.example.com,rtr.example.com` in the description field. In this case, `rtr.example.com` will always be selected, but is this the desired result for the operator?