### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        python-versions: ['3.8', '3.9', '3.10', '3.11']
+        python-versions: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
@@ -44,7 +44,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox tox-gh-actions poetry
 
     - name: Test with tox
       run: tox
@@ -72,7 +72,7 @@ jobs:
       run: ls -Rla ${{steps.download.outputs.download-path}}
 
     - name: 🚀 Publish code coverage to Code Climate
-      uses: paambaati/codeclimate-action@v8.0.0
+      uses: paambaati/codeclimate-action@v9.0.0
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       with:
@@ -99,13 +99,12 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.13'
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install poetry
-        poetry self add "poetry-dynamic-versioning[plugin]"
 
     - name: Build wheels and source tarball
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-versions: ['3.11']
+        python-versions: ['3.13']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -37,7 +37,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry
-        poetry self add "poetry-dynamic-versioning[plugin]"
 
     - name: Push tag
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: forbid-tabs
   - id: remove-tabs
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: check-added-large-files
   - id: check-builtin-literals
@@ -18,22 +18,17 @@ repos:
   - id: forbid-new-submodules
   - id: trailing-whitespace
   - id: mixed-line-ending
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.9.2
   hooks:
-  - id: isort
-    files: \.py$
-- repo: https://github.com/psf/black
-  rev: 24.8.0
-  hooks:
-  - id: black
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.1.1
-  hooks:
-  - id: flake8
-    additional_dependencies: [flake8-typing-imports]
+    # Run the linter.
+  - id: ruff
+    args: [--fix]
+    # Run the formatter.
+  - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.11.1
+  rev: v1.14.1
   hooks:
   - id: mypy
     files: octodns_netbox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ $ git clone git@github.com:your_name_here/octodns-netbox.git
 4. Install dependencies and start your virtualenv:
 
 ```
-$ poetry install
+$ poetry install --with dev
 ```
 
 5. Create a branch for local development:

--- a/octodns_netbox/__init__.py
+++ b/octodns_netbox/__init__.py
@@ -24,7 +24,7 @@ import pynetbox
 import requests
 from octodns.record import Record, Rr
 from octodns.source.base import BaseSource
-from octodns.zone import DuplicateRecordException, SubzoneRecordException, Zone
+from octodns.zone import SubzoneRecordException, Zone
 from pydantic import (
     AnyHttpUrl,
     BaseModel,

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[virtualenvs]
-in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,65 +2,49 @@
 build-backend = "poetry_dynamic_versioning.backend"
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 
-[tool]
-
-[tool.black]
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
-include = '\.pyi?$'
-line-length = 88
-
-[tool.poetry]
-authors = ["Masaki Tagawa <masaki@sukiyaki.ski>"]
+[project]
+authors = [
+  {name = "Tagawa, Masaki", email = "masaki@tagawa.email"}
+]
 classifiers = [
   'Development Status :: 4 - Beta',
   'Intended Audience :: Developers',
   'License :: OSI Approved :: MIT License',
   'Natural Language :: English',
   'Programming Language :: Python :: 3',
-  'Programming Language :: Python :: 3.8',
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
-  'Programming Language :: Python :: 3.11'
+  'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13'
+]
+dependencies = [
+  "octodns (>=1.10.0,<2.0.0)",
+  "pydantic (>=2.10.5,<3.0.0)",
+  "pynetbox (>=7.4.1,<8.0.0)",
+  "requests (>=2.32.3,<3.0.0)",
+  "typing-extensions (>=4.12.2,<5.0.0) ; python_version < '3.9'"
 ]
 description = "A NetBox source for octoDNS."
+dynamic = ["version"]
 homepage = "https://github.com/sukiyaki/octodns-netbox"
 license = "MIT"
 name = "octodns-netbox"
-packages = [
-  {include = "octodns_netbox"},
-  {include = "tests", format = "sdist"}
-]
 readme = "README.md"
+requires-python = ">=3.9,<4"
+
+[tool.poetry]
 version = "0.0.0"
 
-[tool.poetry.dependencies]
-octodns = {version = "^1.0.0"}
-poetry = "^1.7.1"
-pydantic = "^2.0.0"
-pynetbox = {version = "^7.0.0"}
-python = ">=3.8,<4.0"
-requests = {version = "^2.31.0"}
-typing-extensions = {version = "^4.9.0", python = "<3.9"}
-
-[tool.poetry.dev-dependencies]
-pre-commit = "^3.0.0"
+[tool.poetry.group.dev.dependencies]
+pre-commit = "^4.0.0"
 pytest = "^8.0.0"
-pytest-cov = "^5.0.0"
-requests-mock = "^1.11.0"
+pytest-cov = "^6.0.0"
+requests-mock = "^1.12.0"
 tox = "^4.0.0"
+
+[tool.poetry.requires-plugins]
+poetry-dynamic-versioning = {version = ">=1.0.0,<2.0.0", extras = ["plugin"]}
 
 [tool.poetry-dynamic-versioning]
 bump = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,45 +1,39 @@
 [tox]
 isolated_build = true
 envlist =
-    py38, py39, py310, py311
-    coverage, lint, packaging
+    py39, py310, py311, py312, py313
+    lint, packaging
 
 [gh-actions]
 python =
-    3.11: py311, coverage, lint, packaging
-    3.10: py310, coverage
-    3.9: py39, coverage
-    3.8: py38, coverage
+    3.13: py313, lint, packaging
+    3.12: py312
+    3.11: py311
+    3.10: py310
+    3.9: py39
 
 [testenv]
 setenv =
     PYTHONIOENCODING=utf-8
     PY_COLORS=1
 passenv = CI
+skip_install = true
 allowlist_externals =
     poetry
 commands_pre =
-   poetry self update
-   poetry self add "poetry-dynamic-versioning[plugin]"
-   poetry run python -m pip install pip -U
+    poetry self update
+    poetry install --with dev -v
 commands =
-   poetry install --no-root -v
-   poetry run pytest []
-
-[testenv:coverage]
-basepython = python3
-commands =
-   poetry install --no-root -v
-   poetry run pytest --cov=octodns_netbox --cov-report=xml --cov-report term-missing []
+    poetry run pytest --cov=octodns_netbox --cov-report=xml --cov-report term-missing []
 
 [testenv:packaging]
 skip_install = True
 deps =
-   poetry
-   twine
+    poetry
+    twine
 commands =
-   poetry build
-   twine check dist/*
+    poetry build
+    twine check dist/*
 
 [testenv:lint]
 skip_install = True
@@ -47,4 +41,4 @@ passenv = TERM
 deps = pre-commit
 commands_pre =
 commands =
-   pre-commit run [] --all-files --show-diff-on-failure --hook-stage=manual
+    pre-commit run [] --all-files --show-diff-on-failure --hook-stage=manual


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Poetry to v2 and Python to 3.9+, along with other dependencies. Replace Flake8, Black, and isort with Ruff. Update pre-commit hooks and CI workflows to reflect these changes.

Build:
- Update Poetry to v2.

CI:
- Update CI workflows to use Python 3.9+ and drop support for Python 3.8.
- Update Code Climate action to v9.

Tests:
- Update test dependencies.