### PR TITLE
Add missing 'poetry install' step before building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry
+        poetry install
 
     - name: Build wheels and source tarball
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry
+        poetry install
 
     - name: Push tag
       run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Install project dependencies using `poetry install`.