### PR TITLE
feat: NetBox custom fields and multi-field `field_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ To create A/AAAA records for octoDNS, you need to manage the mapping between IP 
 
 Starting with [Netbox v2.6.0](https://github.com/netbox-community/netbox/issues/166), Netbox now has a `dns_name` field in IP address records. But we **do not** use this field by default because this `dns_name` field can only store **single** FQDN. To use a `dns_name` field, set `field_name: dns_name` in [the configuration](#examples).
 
+### Custom fields
+
+You can also use NetBox custom fields to store DNS names. This is useful when you want to keep the `dns_name` field for the primary hostname and use a custom field for additional aliases.
+
+To use a custom field, prefix the field name with `cf_`. For example, if you have a custom field named `additional_dns` on IP addresses, configure it as:
+
+```yaml
+providers:
+  netbox-aliases:
+    class: octodns_netbox.NetboxSource
+    url: https://ipam.example.com
+    token: env/NETBOX_TOKEN
+    field_name: cf_additional_dns
+```
+
+The custom field should contain comma-separated FQDNs, just like the `description` field.
+
 ### PTR records
 
 `octodns-netbox` also supports PTR records. By default, only the first FQDN in the field is used to generate the PTR record, but you can enable multiple PTR records for a single IP by setting the `multivalue_ptr` parameter to `true` in [the configuration](#examples).
@@ -92,6 +109,10 @@ providers:
     # The `description` does not have any limitations so by default
     # we use the `description` field to store multiple FQDNs, separated by commas.
     # Other tested values are `dns_name`.
+    #
+    # Custom fields are also supported by using the `cf_` prefix.
+    # For example, if you have a custom field named `additional_dns`,
+    # set `field_name: cf_additional_dns`.
     field_name: description
 
     # Tag Name (Optional)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ To create A/AAAA records for octoDNS, you need to manage the mapping between IP 
 
 Starting with [Netbox v2.6.0](https://github.com/netbox-community/netbox/issues/166), Netbox now has a `dns_name` field in IP address records. But we **do not** use this field by default because this `dns_name` field can only store **single** FQDN. To use a `dns_name` field, set `field_name: dns_name` in [the configuration](#examples).
 
+`field_name` also accepts a list of field names, e.g. `field_name: [dns_name, description]`. When a list is given, A/AAAA records are produced from the deduplicated union of FQDNs parsed from every listed field — so one IP can carry a canonical FQDN in `dns_name` **and** additional aliases in `description`, and all become A/AAAA records. See the [list-form section](#multi-field-field_name) for details.
+
 ### Custom fields
 
 You can also use NetBox custom fields to store DNS names. This is useful when you want to keep the `dns_name` field for the primary hostname and use a custom field for additional aliases.
@@ -48,13 +50,13 @@ providers:
     field_name: cf_additional_dns
 ```
 
-The custom field should contain comma-separated FQDNs, just like the `description` field.
+The custom field should contain comma-separated FQDNs, just like the `description` field. Custom fields compose with the list form: any entry in a list-valued `field_name` may be a `cf_*` custom field, e.g. `field_name: [dns_name, cf_additional_dns]`.
 
 ### PTR records
 
 `octodns-netbox` also supports PTR records. By default, only the first FQDN in the field is used to generate the PTR record, but you can enable multiple PTR records for a single IP by setting the `multivalue_ptr` parameter to `true` in [the configuration](#examples).
 
-#### 🔍 Example (`multivalue_ptr: false` - default)
+#### Example (`multivalue_ptr: false` - default)
 - IP Address: `192.0.2.1/24`
   - Description: `en0.host1.example.com,host1.example.com`
 - DNS Zone: `2.0.192.in-addr.arpa.`
@@ -66,6 +68,46 @@ The custom field should contain comma-separated FQDNs, just like the `descriptio
 - DNS Zone: `2.0.192.in-addr.arpa.`
   - `1. PTR en0.host1.example.com.`
   - `1. PTR host1.example.com.`
+
+### Multi-field `field_name`
+
+`field_name` accepts either a single field name (string, the default `description`) or a list of field names. When a list is given, the source reads from every listed field and produces records from the **union** of the FQDNs it finds.
+
+The fields in the list have an ordering: the **first field is the primary**. The primary field is what the NetBox API is queried against for the server-side filter (`__ic=<zone>` / `__empty=false`), and it is the sole source for single-valued PTR records (when `multivalue_ptr: false`, which is the default). Every field contributes to forward A/AAAA records and to multi-valued PTR records.
+
+This means one IP record in NetBox can produce a single canonical PTR (from `dns_name`) **and** multiple A/AAAA records (from `dns_name` *and* `description` aliases), all from a single `NetboxSource` instance.
+
+#### Example: one PTR + multiple A records from a single IP
+
+Assume an IP address in NetBox:
+- IP: `192.0.2.1/24`
+- `dns_name`: `host.example.com`
+- `description`: `alias-a.example.com, alias-b.example.com`
+
+With `field_name: [dns_name, description]` and `multivalue_ptr: false` (default), the resulting records are:
+
+- Forward zone `example.com.`:
+  - `host       A  192.0.2.1`
+  - `alias-a    A  192.0.2.1`
+  - `alias-b    A  192.0.2.1`
+- Reverse zone `2.0.192.in-addr.arpa.`:
+  - `1  PTR  host.example.com.`  *(from `dns_name` only — single canonical name)*
+
+#### Semantics summary
+
+| Context                                    | Fields consulted | FQDNs taken                                      |
+|--------------------------------------------|------------------|--------------------------------------------------|
+| PTR with `multivalue_ptr: false` (default) | all fields       | first FQDN of the deduplicated union (in order)  |
+| PTR with `multivalue_ptr: true`            | all fields       | deduplicated union                               |
+| Forward A/AAAA                             | all fields       | deduplicated union                               |
+
+For single-valued PTR (the default), fields are consulted in order — the first non-empty field that yields an FQDN wins, so primary `dns_name` takes precedence over fallback fields.
+
+#### NetBox API filter scope
+
+The source issues one NetBox `ipam.ip_addresses.filter(...)` call per configured field and unions the results, deduplicated by IP address ID. An IP is fetched if **any** configured field's per-field filter matches (`<field>__ic=<zone>` for forward zones, `<field>__empty=false` for reverse zones). This means an IP whose primary field is empty but whose secondary field carries an in-zone FQDN **is** fetched and contributes records.
+
+Backwards compatibility: omitting `field_name` entirely, or setting it to a string, continues to work identically. A single string is treated as a one-element list internally.
 
 #### Classless subnet delegation (IPv4 /31 to /25)
 
@@ -113,6 +155,16 @@ providers:
     # Custom fields are also supported by using the `cf_` prefix.
     # For example, if you have a custom field named `additional_dns`,
     # set `field_name: cf_additional_dns`.
+    #
+    # `field_name` also accepts a list of field names; the source queries every
+    # listed field with OR semantics and unions the resulting FQDNs (deduped,
+    # order-preserving). The first field is the "primary" — for single-valued
+    # PTR records (`multivalue_ptr: false`, the default), only the primary
+    # field's FQDNs are considered, falling through to the next field when the
+    # primary is empty. List entries may themselves be `cf_*` custom fields,
+    # e.g. `field_name: [dns_name, cf_additional_dns]`. See the "Multi-field
+    # `field_name`" section above.
+    #   field_name: [dns_name, description]
     field_name: description
 
     # Tag Name (Optional)

--- a/octodns_netbox/__init__.py
+++ b/octodns_netbox/__init__.py
@@ -59,7 +59,7 @@ class NetboxSourceConfig(BaseModel):
     id: str
     url: Url
     token: str
-    field_name: str = "description"
+    field_name: typing.List[str] = ["description"]
     populate_tags: typing.List[str] = []
     populate_vrf_id: Annotated[
         typing.Union[int, Literal["null"], None], Field(validate_default=True)
@@ -85,6 +85,37 @@ class NetboxSourceConfig(BaseModel):
         """
         if re.search(r"/api/?$", v):
             v = re.sub(r"/api/?$", "", v)
+        return v
+
+    @field_validator("field_name", mode="before")
+    def normalize_field_name(cls, v: typing.Any) -> typing.List[str]:
+        """
+        Normalizes `field_name` to an ordered list of NetBox field names.
+
+        Accepts either a single string (legacy form) or a list of strings.
+        A single string is promoted to a single-element list so downstream
+        code always operates on a uniform list shape. The first element is
+        treated as the "primary" field for server-side filtering and for
+        single-valued PTR records.
+
+        Args:
+            v: The raw `field_name` value (str or list[str]).
+
+        Returns:
+            list[str]: A non-empty ordered list of NetBox field names.
+
+        Raises:
+            ValueError: If the list is empty or contains non-string / empty entries.
+        """
+        if isinstance(v, str):
+            v = [v]
+        if not isinstance(v, list) or not v:
+            raise ValueError(
+                "field_name must be a non-empty string or list of strings."
+            )
+        for entry in v:
+            if not isinstance(entry, str) or not entry.strip():
+                raise ValueError("field_name list entries must be non-empty strings.")
         return v
 
     @field_validator("populate_vrf_name")
@@ -241,26 +272,28 @@ class NetboxSource(BaseSource, NetboxSourceConfig):
             List[Rr]: A list of Rr objects for PTR records.
         """
         network = octodns_netbox.reversename.to_network(zone)
-        filter_kwargs = self._build_ptr_filter_kwargs(network, family)
-
-        ipam_records = self._nb_client.ipam.ip_addresses.filter(**filter_kwargs)
+        base_kwargs = self._build_ptr_filter_kwargs(network, family)
+        ipam_records = self._query_ip_addresses_per_field(
+            base_kwargs, field_filter_suffix="__empty", field_filter_value="false"
+        )
         return self._build_ptr_records(zone, ipam_records)
 
     def _build_ptr_filter_kwargs(
         self, network: typing.Any, family: Literal[4, 6]
     ) -> dict[str, typing.Any]:
         """
-        Builds the filter kwargs for NetBox queries when populating PTR records.
+        Builds the *base* filter kwargs (everything except the per-field part)
+        for NetBox queries when populating PTR records. The per-field part
+        (`<field>__empty=false`) is added per-query by `_query_ip_addresses_per_field`.
 
         Args:
             network (Any): The IP network derived from the reverse zone.
             family (Literal[4, 6]): The IP family (4 or 6).
 
         Returns:
-            dict[str, Any]: A dictionary of filter criteria for NetBox.
+            dict[str, Any]: Base filter criteria shared across all per-field queries.
         """
-        filter_kwargs = {
-            f"{self.field_name}__empty": "false",
+        filter_kwargs: dict[str, typing.Any] = {
             "parent": network.compressed,
             "family": family,
             "vrf_id": self.populate_vrf_id,
@@ -297,9 +330,12 @@ class NetboxSource(BaseSource, NetboxSourceConfig):
             ptr_name = zone.hostname_from_fqdn(
                 octodns_netbox.reversename.from_address(zone, ip_address)
             )
-            # Potentially multiple FQDNs in the designated field
-            fqdns = self._parse_fqdns_list(
-                self._get_field_value(ipam_record),
+            # Both PTR modes union across all configured fields with order-preserving
+            # dedup; single-valued PTR (default) caps the result at one FQDN, naturally
+            # falling through from an empty primary field to the next-non-empty field.
+            fqdns = self._collect_fqdns(
+                ipam_record,
+                fields=self.field_name,
                 len_limit=None if self.multivalue_ptr else 1,
             )
             for fqdn in fqdns:
@@ -318,30 +354,72 @@ class NetboxSource(BaseSource, NetboxSourceConfig):
         Returns:
             List[Rr]: A list of Rr objects for A/AAAA records.
         """
-        filter_kwargs = self._build_forward_filter_kwargs(zone)
-        ipam_records = self._nb_client.ipam.ip_addresses.filter(**filter_kwargs)
-
+        zone_name_no_dot = zone.name.rstrip(".")
+        base_kwargs = self._build_forward_filter_kwargs(zone)
+        ipam_records = self._query_ip_addresses_per_field(
+            base_kwargs,
+            field_filter_suffix="__ic",
+            field_filter_value=zone_name_no_dot,
+        )
         return self._build_forward_records(zone, ipam_records)
 
     def _build_forward_filter_kwargs(self, zone: Zone) -> dict[str, typing.Any]:
         """
-        Builds the filter kwargs for NetBox queries when populating forward A/AAAA records.
+        Builds the *base* filter kwargs (everything except the per-field part)
+        for NetBox queries when populating forward A/AAAA records. The per-field
+        part (`<field>__ic=<zone>`) is added per-query by
+        `_query_ip_addresses_per_field`.
 
         Args:
             zone (Zone): The forward zone for which to build query filters.
 
         Returns:
-            dict[str, Any]: A dictionary of filter criteria for NetBox queries.
+            dict[str, Any]: Base filter criteria shared across all per-field queries.
         """
-        zone_name_no_dot = zone.name.rstrip(".")
-        filter_kwargs = {
-            f"{self.field_name}__ic": zone_name_no_dot,
+        filter_kwargs: dict[str, typing.Any] = {
             "vrf_id": self.populate_vrf_id,
             "tag": self.populate_tags,
         }
         if filter_kwargs["vrf_id"] is None:
             del filter_kwargs["vrf_id"]
         return filter_kwargs
+
+    def _query_ip_addresses_per_field(
+        self,
+        base_kwargs: dict[str, typing.Any],
+        field_filter_suffix: str,
+        field_filter_value: typing.Any,
+    ) -> typing.Iterator[typing.Any]:
+        """
+        Runs one NetBox `ipam.ip_addresses.filter(...)` query per configured
+        field in `self.field_name`, applying the same per-field lookup
+        (`<field><field_filter_suffix>=<field_filter_value>`) on top of the
+        shared `base_kwargs`. Results are deduplicated by IP address `id`,
+        preserving first-seen order across fields, so an IP that appears in
+        multiple per-field queries is yielded once.
+
+        This implements an OR-across-fields filter: an IP is fetched if *any*
+        configured field's per-field filter matches.
+
+        Args:
+            base_kwargs: kwargs shared across all per-field queries
+                (e.g. `parent`, `family`, `vrf_id`, `tag`).
+            field_filter_suffix: NetBox lookup suffix (e.g. `"__empty"`, `"__ic"`).
+            field_filter_value: value passed to that lookup (e.g. `"false"`,
+                a zone name).
+
+        Yields:
+            IPAM records, deduplicated by id, in first-seen order across fields.
+        """
+        seen_ids: typing.Set[typing.Any] = set()
+        for field in self.field_name:
+            kwargs = dict(base_kwargs)
+            kwargs[f"{field}{field_filter_suffix}"] = field_filter_value
+            for ipam_record in self._nb_client.ipam.ip_addresses.filter(**kwargs):
+                if ipam_record.id in seen_ids:
+                    continue
+                seen_ids.add(ipam_record.id)
+                yield ipam_record
 
     def _build_forward_records(
         self, zone: Zone, ipam_records: typing.Iterable[typing.Any]
@@ -384,8 +462,8 @@ class NetboxSource(BaseSource, NetboxSourceConfig):
         ip_address = ip_interface(ipam_record.address).ip
         record_type: Literal["A", "AAAA"] = "A" if ip_address.version == 4 else "AAAA"
 
-        # Parse out any FQDNs listed in the desired NetBox field
-        fqdns = self._parse_fqdns_list(self._get_field_value(ipam_record))
+        # Union FQDNs across every configured NetBox field (deduped, order-preserving).
+        fqdns = self._collect_fqdns(ipam_record, fields=self.field_name)
 
         # For each FQDN, determine if it belongs to this zone and create records
         for fqdn in fqdns:
@@ -466,29 +544,65 @@ class NetboxSource(BaseSource, NetboxSourceConfig):
         ]
         return fqdns[:len_limit] if len_limit else fqdns
 
-    def _get_field_value(self, ipam_record: typing.Any) -> str:
+    def _collect_fqdns(
+        self,
+        ipam_record: typing.Any,
+        fields: typing.List[str],
+        len_limit: typing.Optional[int] = None,
+    ) -> typing.List[str]:
         """
-        Retrieves the value of the configured field from an IPAM record.
+        Collects FQDNs from multiple NetBox fields on a single IPAM record,
+        preserving order and deduplicating across fields.
 
-        Supports both standard fields (e.g., 'dns_name', 'description') and
-        custom fields (prefixed with 'cf_'). Custom fields are accessed via
-        the 'custom_fields' dictionary on the IPAM record.
+        Each listed field is read in order via `_get_field_value` (which handles
+        both standard fields and `cf_`-prefixed custom fields); its value (if
+        non-empty and str-typed) is passed through `_parse_fqdns_list` for
+        per-field comma-splitting and normalization. The results are concatenated
+        and deduplicated, with the first occurrence of each normalized FQDN winning.
+
+        Args:
+            ipam_record: A NetBox IPAM record.
+            fields: Ordered list of field names to consult. Entries prefixed with
+                `cf_` are read from the record's `custom_fields` dictionary.
+            len_limit: If set, truncates the final deduplicated list to this size.
+
+        Returns:
+            List[str]: Deduplicated, order-preserving list of normalized FQDNs.
+        """
+        collected: typing.List[str] = []
+        for field in fields:
+            value = self._get_field_value(ipam_record, field)
+            if not isinstance(value, str) or not value:
+                continue
+            collected.extend(self._parse_fqdns_list(value))
+        deduped = list(dict.fromkeys(collected))
+        return deduped[:len_limit] if len_limit else deduped
+
+    def _get_field_value(self, ipam_record: typing.Any, field: str) -> typing.Any:
+        """
+        Retrieves the raw value of a single field from an IPAM record.
+
+        Supports both standard fields (e.g. `dns_name`, `description`) and
+        custom fields (prefixed with `cf_`). Custom fields are accessed via
+        the `custom_fields` dictionary on the IPAM record, with the `cf_`
+        prefix stripped to obtain the NetBox custom-field key.
 
         Args:
             ipam_record (Any): A single IPAM record from NetBox.
+            field (str): The configured field name (with `cf_` prefix for
+                custom fields).
 
         Returns:
-            str: The field value, or an empty string if the field is not set.
+            Any: The raw field value (typically `str` or `None`). Callers are
+                expected to validate the type before use.
 
         Examples:
-            - field_name='dns_name' -> ipam_record['dns_name']
-            - field_name='cf_additional_dns' -> ipam_record.custom_fields['additional_dns']
+            - `field='dns_name'` -> `ipam_record['dns_name']`
+            - `field='cf_additional_dns'` ->
+              `ipam_record.custom_fields['additional_dns']`
         """
-        if self.field_name.startswith("cf_"):
-            # Custom field: strip 'cf_' prefix and access via custom_fields
-            custom_field_name = self.field_name[3:]
+        if field.startswith("cf_"):
+            custom_field_name = field[3:]
             custom_fields = getattr(ipam_record, "custom_fields", {}) or {}
-            return custom_fields.get(custom_field_name, "") or ""
-        else:
-            # Standard field: access directly
-            return ipam_record[self.field_name] or ""
+            return custom_fields.get(custom_field_name)
+        return ipam_record[field]

--- a/tests/test_octodns_netbox.py
+++ b/tests/test_octodns_netbox.py
@@ -92,6 +92,11 @@ def mock_requests():
             json=load_fixture("ip_addresses_subdomain1_example_com.json"),
         )
         mock.get(
+            "http://netbox.example.com/api/ipam/ip-addresses/?dns_name__ic=subdomain1.example.com&limit=0",
+            complete_qs=True,
+            json=load_fixture("ip_addresses_subdomain1_example_com.json"),
+        )
+        mock.get(
             "http://netbox.example.com/api/ipam/ip-addresses/?dns_name__ic=example.com&limit=0",
             complete_qs=True,
             json=load_fixture("ip_addresses_example_com.json"),
@@ -123,17 +128,49 @@ class TestNetboxSourceFailSenarios:
         )
         assert source.url == "http://netbox.example.com"
 
-    def test_init_failed_due_to_invalid_field_name_type(self):
+    def test_init_failed_due_to_invalid_field_name_empty_list(self):
         with pytest.raises(ValidationError) as excinfo:
             NetboxSource(
                 "test",
                 url="http://netbox.example.com/",
                 token="testtoken",
-                field_name=["dns_name", "description"],
+                field_name=[],
             )
 
         assert excinfo.value.errors()[0]["loc"] == ("field_name",)
-        assert excinfo.value.errors()[0]["type"] == "string_type"
+
+    def test_init_failed_due_to_invalid_field_name_empty_string_entry(self):
+        with pytest.raises(ValidationError) as excinfo:
+            NetboxSource(
+                "test",
+                url="http://netbox.example.com/",
+                token="testtoken",
+                field_name=["dns_name", ""],
+            )
+
+        assert excinfo.value.errors()[0]["loc"] == ("field_name",)
+
+    def test_init_failed_due_to_invalid_field_name_non_string_entry(self):
+        with pytest.raises(ValidationError) as excinfo:
+            NetboxSource(
+                "test",
+                url="http://netbox.example.com/",
+                token="testtoken",
+                field_name=["dns_name", 123],
+            )
+
+        assert excinfo.value.errors()[0]["loc"] == ("field_name",)
+
+    def test_init_failed_due_to_invalid_field_name_wrong_type(self):
+        with pytest.raises(ValidationError) as excinfo:
+            NetboxSource(
+                "test",
+                url="http://netbox.example.com/",
+                token="testtoken",
+                field_name=123,
+            )
+
+        assert excinfo.value.errors()[0]["loc"] == ("field_name",)
 
     def test_init_failed_due_to_invalid_ttl_type(self):
         with pytest.raises(ValidationError) as excinfo:
@@ -1129,3 +1166,374 @@ class TestNetboxSourcePopulateNormal:
 
         assert "Skipping subzone record" in caplog.text
         assert len(zone.records) == 6
+
+
+class _FakeIpamRecord:
+    """Minimal stand-in for a pynetbox Record supporting `r[field]` lookups
+    and (optionally) a `custom_fields` dict for `cf_*` field testing."""
+
+    def __init__(self, address: str, fields: dict, custom_fields: dict | None = None):
+        self.address = address
+        self._fields = fields
+        self.custom_fields = custom_fields or {}
+
+    def __getitem__(self, key: str):
+        return self._fields.get(key)
+
+
+class TestNetboxSourceFieldNameList:
+    """Covers the list-form `field_name` capability.
+
+    Unit-level tests for the `_collect_fqdns` helper and filter kwargs;
+    integration-level tests over the existing example.com fixture, which
+    carries both `dns_name` and `description` populated on every record.
+    """
+
+    def _make_source(self, **overrides):
+        defaults = {
+            "url": "http://netbox.example.com/",
+            "token": "testtoken",
+        }
+        defaults.update(overrides)
+        return NetboxSource("test", **defaults)
+
+    # --- Config surface / backcompat ---
+
+    def test_string_form_normalizes_to_single_element_list(self):
+        source = self._make_source(field_name="dns_name")
+        assert source.field_name == ["dns_name"]
+
+    def test_default_is_single_element_list(self):
+        source = self._make_source()
+        assert source.field_name == ["description"]
+
+    def test_list_form_is_preserved(self):
+        source = self._make_source(field_name=["dns_name", "description"])
+        assert source.field_name == ["dns_name", "description"]
+
+    # --- _collect_fqdns helper ---
+
+    def test_collect_fqdns_unions_across_fields(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {
+                "dns_name": "host.example.com.",
+                "description": "alias-a.example.com., alias-b.example.com.",
+            },
+        )
+        result = source._collect_fqdns(record, fields=["dns_name", "description"])
+        assert result == [
+            "host.example.com.",
+            "alias-a.example.com.",
+            "alias-b.example.com.",
+        ]
+
+    def test_collect_fqdns_dedupes_order_preserving(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {
+                "dns_name": "host.example.com.",
+                "description": "host.example.com., alias.example.com.",
+            },
+        )
+        result = source._collect_fqdns(record, fields=["dns_name", "description"])
+        assert result == ["host.example.com.", "alias.example.com."]
+
+    def test_collect_fqdns_skips_empty_fields(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {"dns_name": "", "description": "alias.example.com."},
+        )
+        result = source._collect_fqdns(record, fields=["dns_name", "description"])
+        assert result == ["alias.example.com."]
+
+    def test_collect_fqdns_skips_none_fields(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {"dns_name": None, "description": "alias.example.com."},
+        )
+        result = source._collect_fqdns(record, fields=["dns_name", "description"])
+        assert result == ["alias.example.com."]
+
+    def test_collect_fqdns_len_limit_truncates_after_dedup(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {
+                "dns_name": "host.example.com.",
+                "description": "host.example.com., alias.example.com.",
+            },
+        )
+        result = source._collect_fqdns(
+            record, fields=["dns_name", "description"], len_limit=1
+        )
+        assert result == ["host.example.com."]
+
+    def test_collect_fqdns_first_field_empty_single_field_no_result(self):
+        """Single-valued PTR semantics: empty first field → no FQDN."""
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {"dns_name": "", "description": "alias.example.com."},
+        )
+        result = source._collect_fqdns(record, fields=["dns_name"], len_limit=1)
+        assert result == []
+
+    # --- Filter base kwargs are field-agnostic ---
+
+    def test_ptr_base_filter_kwargs_have_no_field_part(self):
+        """Base PTR kwargs are shared across per-field queries; the per-field
+        `__empty` key is added in `_query_ip_addresses_per_field`, not here."""
+        import ipaddress
+
+        source = self._make_source(field_name=["dns_name", "description"])
+        network = ipaddress.ip_network("192.0.2.0/24")
+        kwargs = source._build_ptr_filter_kwargs(network, family=4)
+        assert not any("__empty" in k for k in kwargs)
+        assert "parent" in kwargs and "family" in kwargs
+
+    def test_forward_base_filter_kwargs_have_no_field_part(self):
+        """Base forward kwargs are shared across per-field queries; the per-field
+        `__ic` key is added in `_query_ip_addresses_per_field`, not here."""
+        source = self._make_source(field_name=["dns_name", "description"])
+        zone = Zone("example.com.", [])
+        kwargs = source._build_forward_filter_kwargs(zone)
+        assert not any("__ic" in k for k in kwargs)
+
+    def test_per_field_query_runs_one_request_per_field(self, mock_requests):
+        """OR-across-fields: configuring [dns_name, description] hits both
+        per-field URLs when populating a forward zone."""
+        zone = Zone("example.com.", [])
+        source = self._make_source(field_name=["dns_name", "description"])
+        source.populate(zone)
+
+        urls = [r.url for r in mock_requests.request_history]
+        assert any("dns_name__ic=example.com" in u for u in urls)
+        assert any("description__ic=example.com" in u for u in urls)
+
+    def test_per_field_query_dedupes_overlapping_ips_by_id(self, mock_requests):
+        """When per-field queries return overlapping IPs (same id), each IP
+        contributes records once. The fixture is identical for both fields,
+        so every IP appears in both queries."""
+        zone = Zone("example.com.", [])
+        source = self._make_source(field_name=["dns_name", "description"])
+        source.populate(zone)
+
+        # Compare counts: with [dns_name, description] vs string-form `description`.
+        # The set of unique IPs is identical (same fixture); union of FQDNs is a
+        # superset of either single field's FQDNs, but no IP is processed twice.
+        zone_string = Zone("example.com.", [])
+        source_string = self._make_source(field_name="description")
+        source_string.populate(zone_string)
+
+        # Every record in the string-form zone (description-only FQDNs)
+        # has a corresponding record in the list-form zone, with no duplicate.
+        list_form_records = list(zone.records)
+        # Ensure no two records share the same (name, type) — that would mean
+        # an IP was processed twice.
+        seen_keys = set()
+        for r in list_form_records:
+            key = (r.name, r._type, tuple(r.values))
+            assert key not in seen_keys, f"duplicate record from dedup miss: {key}"
+            seen_keys.add(key)
+
+    # --- Integration: forward zone with [dns_name, description] ---
+
+    def test_populate_forward_list_form_unions_both_fields(self):
+        """With [dns_name, description], host1 produces records from both fields.
+
+        Fixture record 192.0.4.1 has dns_name=dnsname-host1.example.com
+        and description=description-host1.example.com; both should become A records.
+        """
+        zone = Zone("example.com.", [])
+        source = self._make_source(field_name=["dns_name", "description"])
+        source.populate(zone)
+
+        # Find all A records for 192.0.4.1
+        v4_records = [
+            r for r in zone.records if r._type == "A" and "192.0.4.1" in r.values
+        ]
+        names = {r.name for r in v4_records}
+        assert "dnsname-host1" in names
+        assert "description-host1" in names
+
+    # --- PTR single-valued from first field ---
+
+    def test_populate_ptr_default_single_valued_first_field_only(self):
+        """Default (multivalue_ptr=false) with [dns_name, description] takes dns_name only."""
+        zone = Zone("0/27.2.0.192.in-addr.arpa.", [])
+        source = self._make_source(field_name=["dns_name", "description"])
+        source.populate(zone)
+
+        # First field is dns_name → PTR values should be dnsname-* form, not description-*
+        for r in zone.records:
+            if r._type == "PTR":
+                # Single-valued (default)
+                assert len(r.values) == 1
+                # Value came from dns_name, not description
+                assert "dnsname-" in r.values[0]
+                assert "description-" not in r.values[0]
+
+    # --- PTR fallthrough: empty primary field → next non-empty field ---
+
+    def test_ptr_default_falls_through_empty_first_field(self):
+        """Single-valued PTR with empty primary field falls through to the
+        next-non-empty field's first FQDN (build-level fallthrough)."""
+        zone = Zone("0/27.2.0.192.in-addr.arpa.", [])
+        source = self._make_source(field_name=["dns_name", "description"])
+        fake_record = _FakeIpamRecord(
+            "192.0.2.5/27",
+            {"dns_name": "", "description": "fallback.example.com."},
+        )
+        rrs = source._build_ptr_records(zone, [fake_record])
+        assert len(rrs) == 1
+        assert rrs[0].rdata == "fallback.example.com."
+
+    def test_ptr_default_uses_primary_field_when_populated(self):
+        """When the primary field is populated, the PTR comes from it (no
+        fallthrough), even if a secondary field is also set."""
+        zone = Zone("0/27.2.0.192.in-addr.arpa.", [])
+        source = self._make_source(field_name=["dns_name", "description"])
+        fake_record = _FakeIpamRecord(
+            "192.0.2.5/27",
+            {
+                "dns_name": "primary.example.com.",
+                "description": "alias.example.com.",
+            },
+        )
+        rrs = source._build_ptr_records(zone, [fake_record])
+        assert len(rrs) == 1
+        assert rrs[0].rdata == "primary.example.com."
+
+    # --- PTR multi-valued unions all fields ---
+
+    def test_populate_ptr_multivalue_list_form_unions_all_fields(self):
+        """multivalue_ptr=true with [dns_name, description] unions both fields' FQDNs."""
+        zone = Zone("0/27.2.0.192.in-addr.arpa.", [])
+        source = self._make_source(
+            field_name=["dns_name", "description"], multivalue_ptr=True
+        )
+        source.populate(zone)
+
+        # At least one PTR record should have both a dnsname- and description- value
+        ptr_records = [r for r in zone.records if r._type == "PTR"]
+        assert ptr_records, "expected at least one PTR record"
+        any_multi = any(
+            any("dnsname-" in v for v in r.values)
+            and any("description-" in v for v in r.values)
+            for r in ptr_records
+        )
+        assert any_multi, "expected a PTR record with values from both fields"
+
+    # --- Interaction: populate_subdomains ---
+
+    def test_list_form_respects_populate_subdomains_false(self):
+        """List-form forward union still honors populate_subdomains filtering.
+
+        Uses `description` as the first field so the existing
+        `description__ic=subdomain1.example.com` mock is exercised; the test
+        validates that per-FQDN subdomain gating in `_fqdn_in_zone` is
+        unchanged by the multi-field union path.
+        """
+        zone = Zone("subdomain1.example.com.", [])
+        source = self._make_source(
+            field_name=["description", "dns_name"], populate_subdomains=False
+        )
+        source.populate(zone)
+
+        # Any FQDN with more than one label below the zone name should be dropped
+        for r in zone.records:
+            # r.name is the label below the zone; no dots means one-level-deep
+            assert "." not in r.name
+
+
+class TestNetboxSourceCustomFields:
+    """Covers the `cf_*`-prefixed custom-field capability and its composition
+    with the list-form `field_name`."""
+
+    def _make_source(self, **overrides):
+        defaults = {
+            "url": "http://netbox.example.com/",
+            "token": "testtoken",
+        }
+        defaults.update(overrides)
+        return NetboxSource("test", **defaults)
+
+    def test_get_field_value_standard_field(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {"dns_name": "host.example.com."},
+        )
+        assert source._get_field_value(record, "dns_name") == "host.example.com."
+
+    def test_get_field_value_custom_field_strips_cf_prefix(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {},
+            custom_fields={"aliases": "alias.example.com."},
+        )
+        assert source._get_field_value(record, "cf_aliases") == "alias.example.com."
+
+    def test_get_field_value_custom_field_missing_returns_none(self):
+        source = self._make_source()
+        record = _FakeIpamRecord("192.0.2.1/24", {}, custom_fields={})
+        assert source._get_field_value(record, "cf_missing") is None
+
+    def test_get_field_value_custom_fields_attr_absent(self):
+        """If the IPAM record has no `custom_fields` attribute at all, cf_*
+        lookups return None rather than crashing."""
+
+        class _RecordWithoutCustomFields:
+            def __init__(self):
+                self.address = "192.0.2.1/24"
+
+            def __getitem__(self, key: str):
+                return None
+
+        source = self._make_source()
+        assert source._get_field_value(_RecordWithoutCustomFields(), "cf_x") is None
+
+    def test_collect_fqdns_mixes_standard_and_custom_fields(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {"dns_name": "host.example.com."},
+            custom_fields={"aliases": "alias-a.example.com., alias-b.example.com."},
+        )
+        result = source._collect_fqdns(record, fields=["dns_name", "cf_aliases"])
+        assert result == [
+            "host.example.com.",
+            "alias-a.example.com.",
+            "alias-b.example.com.",
+        ]
+
+    def test_collect_fqdns_cf_only(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {},
+            custom_fields={"aliases": "a.example.com., b.example.com."},
+        )
+        result = source._collect_fqdns(record, fields=["cf_aliases"])
+        assert result == ["a.example.com.", "b.example.com."]
+
+    def test_collect_fqdns_cf_dedupes_against_standard(self):
+        source = self._make_source()
+        record = _FakeIpamRecord(
+            "192.0.2.1/24",
+            {"dns_name": "host.example.com."},
+            custom_fields={"aliases": "host.example.com., other.example.com."},
+        )
+        result = source._collect_fqdns(record, fields=["dns_name", "cf_aliases"])
+        assert result == ["host.example.com.", "other.example.com."]
+
+    def test_string_form_cf_field_normalizes_to_list(self):
+        """Backcompat: a bare `cf_*` string is normalized to a one-element list."""
+        source = self._make_source(field_name="cf_aliases")
+        assert source.field_name == ["cf_aliases"]


### PR DESCRIPTION
This PR extends `field_name` so a `NetboxSource` can read DNS names from any combination of standard NetBox fields and custom fields, all from a single source instance.

- **Custom fields** (commit `5b8f616`): prefix a field with `cf_` to read it from the IPAM record's `custom_fields` dict, e.g. `field_name: cf_additional_dns`.
- **Multi-field list form** (commit `23e4e5e`): `field_name` now accepts a list, e.g. `field_name: [dns_name, description]`. The source issues one `ipam.ip_addresses.filter(...)` call per configured field, deduplicates IPs by `id` (OR-across-fields), and unions the parsed FQDNs (deduplicated, order-preserving) when building records.
- **Composable**: list entries may themselves be `cf_*` custom fields, e.g. `field_name: [dns_name, cf_additional_dns]`.

A single `NetboxSource` instance can therefore produce **one canonical PTR** (from the primary field) and **multiple A/AAAA records** (unioned across every listed field, including custom fields) from a single NetBox IP record.

### Worked example: `[dns_name, cf_additional_dns]`

NetBox IP `192.0.2.1/24`:

- `dns_name`: `host.example.com`
- `cf_additional_dns`: `alias-a.example.com, alias-b.example.com`

With `field_name: [dns_name, cf_additional_dns]` and `multivalue_ptr: false` (default), the resulting records are:

- Forward zone `example.com.`:
  - `host       A  192.0.2.1`
  - `alias-a    A  192.0.2.1`
  - `alias-b    A  192.0.2.1`
- Reverse zone `2.0.192.in-addr.arpa.`:
  - `1  PTR  host.example.com.`  *(single canonical name from the primary field)*

The NetBox API is queried once per configured field. An IP is fetched if **any** configured field's per-field filter matches (`<field>__ic=<zone>` for forward, `<field>__empty=false` for reverse).
This means that if the primary field is empty, it will fall through to the secondary field for PTR generation.

### Backwards compatibility

All existing configurations are unaffected as we convert str -> dict, eg`["description"]`

The `before` validator on `field_name` rejects empty lists, non-string entries, empty-string entries, and wrong types with a clear error.

### New test classes:

- `TestNetboxSourceFieldNameList` — `field_name` validator coverage (empty list, empty/non-string entries, wrong type), `_collect_fqdns` unit tests (union, dedup, skip empty/None, `len_limit` truncation), filter-kwargs shape, per-field query OR semantics with IP-id dedup, integration tests for forward A/AAAA union, single-valued PTR with primary precedence, fallthrough when the primary is empty, multi-valued PTR union, and `populate_subdomains: false` interaction.
- `TestNetboxSourceCustomFields` — `_get_field_value` for standard fields, `cf_*` fields, missing custom-field keys, and records without a `custom_fields` attribute; `_collect_fqdns` mixing `cf_*` with standard fields, `cf_*`-only configurations, and dedup across the two; `cf_*` string-form normalization.
